### PR TITLE
support for SDCC 3.7 or later

### DIFF
--- a/inc/stm8s.h
+++ b/inc/stm8s.h
@@ -84,7 +84,7 @@
  #define _RAISONANCE_
 #elif defined(__ICCSTM8__)
  #define _IAR_
-#elif defined(SDCC)
+#elif defined(SDCC) || defined(__SDCC)
  #define _SDCC_
 #else
  #error "Unsupported Compiler!"          /* Compiler defines not found */


### PR DESCRIPTION
SDCC define is obsolete in SDCC 3.7, so add actual __SDCC define